### PR TITLE
Allow empty stats command

### DIFF
--- a/bot/commands/commands.py
+++ b/bot/commands/commands.py
@@ -79,7 +79,7 @@ async def randomselect(command, msg, user, channel, *args, **kwargs):
 async def stats(command, msg, user, channel, *args, **kwargs):
     cmd = msg.split(' ')[0].lower() if msg.split(' ')[0] else ''
     func_map = kwargs['func_map'] if cmd else []
-    if cmd not in func_map:
+    if cmd and cmd not in func_map:
         return "Invalid Subcommand. " + await help_lizard('','','','')
     stats = read_stat(cmd,func_map)
 


### PR DESCRIPTION
Ease the checking to allow the stats command to show everythign
Offically closes #48
`-Nog`