### PR TITLE
Adjusted !coin-flip, fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ If you have a valid challonge link in your `!bracket` command, Lizard-BOT does n
  * seeding [bracket url ID] [number of players to seed(Must be integer greater than or equal to 1)]
 	 * Seeds the tournament based on points in the spreadsheet and the number of players to seed
 
-`!coin-flip`
-A coin is flipped and the result is returned. Either heads or tails.
-
 `!edit [channel(s)] <setting> <value>`
 There are multiple settings that can be edited to allow customization.
 
@@ -114,6 +111,9 @@ Returns the role that allows access to the administrator commands.
 
 `!bracket`
 Shows the current bracket set in the channel.
+
+`!coin-flip`
+A coin is flipped and the result is returned. Either heads or tails.
 
 `!draw [mention] <game>`
 Conducts a card draw with the message sender and the user mentioned. Game will default to SFV if no game is given.

--- a/bot/commands/bots.json
+++ b/bot/commands/bots.json
@@ -5,12 +5,6 @@
 			"chal",
 			"Uses Challonge's API to pull data into Discord"
 		],
-		"coin-flip": [
-			"coin-flip",
-			"flip",
-			"cf",
-			"A coin is flipped and the result is returned, either heads or tails."
-		],
 		"edit": ["edit","There are multiple settings that can be edited to allow customization. If multiple channels are listed, the setting will be updated to the same value across all listed channels."],
 		"refresh": ["refresh", "Sends a \"REFRESH THE BRACKET\" reminder into the chat."],
 		"remind": ["remind", "Allows the admin to set a timed reminder"],
@@ -24,6 +18,12 @@
 			"Returns the role that allows access to the administrator commands"
 		],
 		"bracket": ["bracket", "Shows the current bracket set in the channel"],
+		"coin-flip": [
+			"coin-flip",
+			"flip",
+			"cf",
+			"A coin is flipped and the result is returned, either heads or tails."
+		],
 		"draw": ["draw", "Draws 7 random characters and conducts a ban pick system. Must mention a user. Will use SFV characters if no game is specified."],
 		"github": ["github", "lizardbot", "Links to the GitHub repository for Lizard-BOT"],
 		"help-lizard": [

--- a/bot/commands/commands.py
+++ b/bot/commands/commands.py
@@ -25,6 +25,16 @@ async def botrole(command, msg, user, channel, *args, **kwargs):
 async def bracket(command, msg, user, channel, *args, **kwargs):
     return read_db('channel', 'bracket', channel.id)
 
+@register('coin-flip')
+@register('flip')
+@register('cf')
+async def coin_flip(command, msg, user, channel, *args, **kwargs):
+    flip = "The coin landed on: {0}"
+    # Flip a coin
+    if int(round(random.random()*10*2)) % 2 == 0:
+        return flip.format(bold("Heads"))
+    return flip.format(bold("Tails"))
+
 @register('draw')
 async def draw(command, msg, user, channel, *args, **kwargs):
     full_msg = kwargs['full_msg']
@@ -370,16 +380,6 @@ async def challonge(command, msg, user, channel, *args, **kwargs):
         else:
             print(parts_get.text)
             raise Exception(bold("Challonge") + ": Unknown Challonge error for " + tour_url)
-
-@register('coin-flip')
-@register('flip')
-@register('cf')
-async def coin_flip(command, msg, user, channel, *args, **kwargs):
-    flip = "The coin landed on: {0}"
-    # Flip a coin
-    if int(round(random.random()*10*2)) % 2 == 0:
-        return flip.format(bold("Heads"))
-    return flip.format(bold("Tails"))
 
 @register('edit')
 async def edit(command, msg, user, channel, *args, **kwargs):

--- a/doc/bot_commands.md
+++ b/doc/bot_commands.md
@@ -23,17 +23,6 @@ Shortcuts: None
 
 Shows the current bracket set in the channel. Can include text also besides just bracket link.  If a Challonge link is in the text, the `!challonge` commands can automatically use the links.
 
-## `!draw [mention] <game>`
-![!draw example](/doc/assets/images/draw.png)
-
-Restricted: No
-
-Shortcuts: None
-
-Conducts a card draw with the message sender and the user mentioned. Game will default to SFV if no game is given.
-First the other user must accept the draw. The player that goes first is randomly chosen by the bot.
-Then 7 random characters are drawn, 2 are banned and 4 are picked.  Everything is controlled by reactions with the order given by the bot.
-
 ## `!challonge <subcommand> [bracket URL identifier] [OPTIONALS] `
 ![!challonge example](/doc/assets/images/challonge.png)
 
@@ -62,12 +51,23 @@ This is because tournaments are read-only by default. Any attempts by Lizard-BOT
 ## `!coin-flip`
 ![!coin-flip example](/doc/assets/images/coin-flip.png)
 
-Restricted: Yes
+Restricted: No
 
 Shortcuts: `!flip` `!cf`
 
 The bot will flip a coin (metaphorically speaking) and return either heads or tails.
 Fun fact: If 4 heads show up in a row, a Gief player just won a round by SPD'ing 4 times.
+
+## `!draw [mention] <game>`
+![!draw example](/doc/assets/images/draw.png)
+
+Restricted: No
+
+Shortcuts: None
+
+Conducts a card draw with the message sender and the user mentioned. Game will default to SFV if no game is given.
+First the other user must accept the draw. The player that goes first is randomly chosen by the bot.
+Then 7 random characters are drawn, 2 are banned and 4 are picked.  Everything is controlled by reactions with the order given by the bot.
 
 ## `!edit [channel(s)] <setting> <value>`
 ![!edit example](/doc/assets/images/edit_example1.png)


### PR DESCRIPTION
Closes #68 

Moved !coin-flip to the unrestricted commands

Fixed documentation ("d" comes after "c" alphabetically) and updated for the change