### PR TITLE
fixed challonge get requests to have a user agent

### DIFF
--- a/bot/commands/challonge.py
+++ b/bot/commands/challonge.py
@@ -2,7 +2,7 @@ from discord.utils import escape_markdown # Regexing fun simplified
 from pprint import pformat
 from requests import get as requests_get, put as requests_put, post as requests_post
 from fuzzywuzzy import fuzz as fuzzywuzzy_fuzz, process as fuzzywuzzy_process
-from json import loads as json_loads, dumps as json_dumps
+from json import loads as json_loads
 
 # Local imports
 from secret import api_key, chal_user

--- a/bot/commands/challonge.py
+++ b/bot/commands/challonge.py
@@ -2,10 +2,10 @@ from discord.utils import escape_markdown # Regexing fun simplified
 from pprint import pformat
 from requests import get as requests_get, put as requests_put, post as requests_post
 from fuzzywuzzy import fuzz as fuzzywuzzy_fuzz, process as fuzzywuzzy_process
-from json import loads as json_loads
+from json import loads as json_loads, dumps as json_dumps
 
 # Local imports
-from secret import api_key
+from secret import api_key, chal_user
 from commands.commands import (help_lizard, not_in_discord)
 from commands.utilities import (register, bold, get_chal_tour_id, get_users, checkin, seeding, read_db)
 
@@ -27,7 +27,7 @@ async def start_challonge(command, msg, channel, guild): # Base url to access Ch
         tour_url = subdomain + '-' + tour_url
 
     # Get the participants for the tournament
-    parts_get = requests_get(base_url + tour_url + "/participants.json", params={'api_key':api_key})
+    parts_get = requests_get(base_url + tour_url + "/participants.json", headers={"User-Agent":"Lizard-BOT"}, auth=(chal_user, api_key))
     if '200' in str(parts_get.status_code):
         return parts_get.json(), tour_url
     elif '404' in str(parts_get.status_code):
@@ -73,7 +73,7 @@ async def challonge_here(command, msg, user, channel, *args, **kwargs):
             raise Exception(bold("Challonge_Here") + ": Lizard-BOT cannot find {0} in the tournament.".format(bold(msg)))
 
         # Send the check in request to Challonge
-        checkin_post = requests_post(base_url + tour_url + "/participants/" + checkin_id +"/check_in.json", params={'api_key':api_key})
+        checkin_post = requests_post(base_url + tour_url + "/participants/" + checkin_id +"/check_in.json", headers={"User-Agent":"Lizard-BOT"}, auth=(chal_user, api_key))
 
         # Check to make sure we get a good response
         if '200' in str(checkin_post.status_code):
@@ -108,7 +108,7 @@ async def challonge_report(command, msg, user, channel, *args, **kwargs):
 
     async with channel.typing():
         parts, tour_url = await start_challonge(command, msg, channel, kwargs['guild']) # Get all the participants and the tournament URL
-        match_get = requests_get(base_url + tour_url + "/matches.json", params={'api_key':api_key, 'state':'open'}) # Grab all the active matches for the tournament
+        match_get = requests_get(base_url + tour_url + "/matches.json", headers={"User-Agent":"Lizard-BOT"}, auth=(chal_user, api_key), params={'state':'open'}) # Grab all the active matches for the tournament
 
         # If we get a good response and there are matches (aka the tournament has been started)
         if '200' in str(match_get.status_code) and match_get.json():
@@ -156,7 +156,7 @@ async def challonge_report(command, msg, user, channel, *args, **kwargs):
                 raise Exception(bold("Challonge_Report") + ": {0} is not a valid score. Example score: 2-0".format(bold(params[0])))
 
             # Time to send out the winner and the score
-            match_put = requests_put(base_url + tour_url + "/matches/" + str(match['id']) +".json", params={'api_key':api_key, 'match[winner_id]':match_parts[winner_name.lower()], 'match[scores_csv]':'-'.join(scores)})
+            match_put = requests_put(base_url + tour_url + "/matches/" + str(match['id']) +".json", headers={"User-Agent":"Lizard-BOT"}, auth=(chal_user, api_key), params={'match[winner_id]':match_parts[winner_name.lower()], 'match[scores_csv]':'-'.join(scores)})
 
             # Check to make sure we get a good response
             if '200' in str(match_put.status_code):

--- a/bot/commands/utilities.py
+++ b/bot/commands/utilities.py
@@ -9,7 +9,7 @@ from re import search as re_search, compile as re_compile # Process strings
 from requests import put as requests_put # HTTP functions
 
 # Local imports
-from secret import (sql_host,sql_port,sql_user,sql_pw,sql_db, api_key) # Store secret information
+from secret import (sql_host,sql_port,sql_user,sql_pw,sql_db, api_key, chal_user) # Store secret information
 from commands.sheets.sheets import sheets # Talk to Google Sheets API
 
 _callbacks = {} # Yaksha
@@ -196,7 +196,7 @@ def seeding(sheet_id, parts, url, seed_num):
             # If Challonge user equals the username we have for seeding
             # Then, update seed number with their index location
             if p['challonge_username'] == finished_seeding[player].split(' ')[0]:
-                response = requests_put(url + "/participants/" + str(p['id']) + ".json", params={'api_key':api_key, 'participant[seed]':player})
+                response = requests_put(url + "/participants/" + str(p['id']) + ".json", headers={"User-Agent":"Lizard-BOT"}, auth=(chal_user, api_key), params={'participant[seed]':player})
                 if '200' in str(response.status_code):
                     continue
                 elif '401' in str(response.status_code):

--- a/doc/new_bot_setup.md
+++ b/doc/new_bot_setup.md
@@ -35,8 +35,9 @@ sql_port = 3306 # DB Server port. Default is 3306
 sql_user = "root" # SQL user. root or admin work.
 sql_pw = "" # SQL user's password
 sql_db = "lizardbot" # DB to access. `lizardbot` is the DB 'create_db.sql' script creates
-token="your-discord-token-here" # Discord Bot token
-api_key="your-challonge-key-here" # Challonge api key
+token = "your-discord-token-here" # Discord Bot token
+api_key = "your-challonge-key-here" # Challonge api key
+chal_user = "your-challonge-username-here" # Challonge username
 ```
 Create a file named secret.py and place it in the the /bot folder with the following info changed to match your specific needs.  You can grab your Discord token from your bot application [here](https://discord.com/developers/applications) and your Challonge key [here](https://challonge.com/settings/developer).
 For more info on setting up API integration with Challonge (or Google Sheets), please review [this](https://github.com/lizardman301/Lizard-bot-rsf/blob/master/doc/api_integration.md)


### PR DESCRIPTION
Closes #106 

Challonge is really dumb and changed how API calls are done. They now require a user agent and a username associated with the key. This should fix the issues

NOTE: ```chal_user``` must now be created in secret.py. Will update documentation shortly.